### PR TITLE
Only post memrise points to beeminder when changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /test/tmp/
 /test/version_tmp/
 /tmp/
+.idea/
 
 ## Specific to RubyMotion:
 .dat*

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ task :memrise do
   beeminder.create_datapoint Memrise.new(username: ENV['MEMRISE_USERNAME'],
                                          password: ENV['MEMRISE_PASSWORD'])
                                     .points
-  end
+end
 
 task :duolingo do
   require './duolingo'

--- a/beeminder.rb
+++ b/beeminder.rb
@@ -22,7 +22,18 @@ class Beeminder
   end
 
   def create_datapoint value
-    Net::HTTP::post_form URI(datapoint_url), value: value
+    if datapoint_changed value
+      Net::HTTP::post_form URI(datapoint_url), value: value
+    end
+  end
+
+  def datapoint_changed value
+    begin
+      last_datapoint = JSON.parse(Net::HTTP::get URI(datapoint_url))[0]['value']
+      last_datapoint.to_i != value
+    rescue Exception => boom
+      raise "Datapoint check failed with: #{boom}"
+    end
   end
 
 end


### PR DESCRIPTION
I am really enjoying your script. I have it running as a cron task and I noticed that Beeminder adds a new datapoint even if the value hasn't changed. To prevent spamming their API with a bunch of updates I added a simple check that just updates it only if there is a change. Let me know what you think.
